### PR TITLE
fix hammer syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,4 +229,4 @@ katello-service restart
 * Add repositiry
 * ssh to workstation
 * ssh sat.example.com
-* hammer -d content capsule synchronize --id=1
+* hammer -d capsule content synchronize --id=2


### PR DESCRIPTION
The correct syntax is "hammer capsule content synchronize" instead of "hammer content capsule synchronize".

With Capsule ID 1, I get "This request may only be performed on a Capsule that has the Pulp Node feature."

Capsule ID 2 seems to work.